### PR TITLE
RelayCommand의 AnyObject 파라미터를 Any로 변경

### DIFF
--- a/TodoList/NewTodoItemFormViewModel.swift
+++ b/TodoList/NewTodoItemFormViewModel.swift
@@ -33,12 +33,12 @@ class NewTodoItemFormViewModel {
     
     var submit: RelayCommand { return _submit! }
     
-    private func executeSubmit(parameter: AnyObject?) {
+    private func executeSubmit(parameter: Any?) {
         _itemList.items.append(item: TodoItemViewModel(description: self.description))
         description = ""
     }
     
-    private func canExecuteSubmit(parameter: AnyObject?) -> Bool {
+    private func canExecuteSubmit(parameter: Any?) -> Bool {
         return description != ""
     }
     

--- a/TodoList/RelayCommand.swift
+++ b/TodoList/RelayCommand.swift
@@ -11,29 +11,29 @@ import RxSwift
 
 class RelayCommand {
     
-    private let _execute: (AnyObject?) -> Void
-    private let _canExecute: (AnyObject?) -> Bool
+    private let _execute: (Any?) -> Void
+    private let _canExecute: (Any?) -> Bool
     private let _canExecuteChanged = PublishSubject<Unit>()
     
-    init(execute: @escaping (AnyObject?) -> Void) {
+    init(execute: @escaping (Any?) -> Void) {
         _execute = execute
         _canExecute = { Void in true }
     }
     
-    init(execute: @escaping (AnyObject?) -> Void, canExecute: @escaping (AnyObject?) -> Bool) {
+    init(execute: @escaping (Any?) -> Void, canExecute: @escaping (Any?) -> Bool) {
         _execute = execute
         _canExecute = canExecute
     }
     
     var canExecuteChanged: Observable<Unit> { return _canExecuteChanged }
     
-    func execute(parameter: AnyObject? = nil) {
+    func execute(parameter: Any? = nil) {
         if canExecute(parameter: parameter) {
             _execute(parameter)
         }
     }
     
-    func canExecute(parameter: AnyObject? = nil) -> Bool {
+    func canExecute(parameter: Any? = nil) -> Bool {
         return _canExecute(parameter)
     }
     

--- a/TodoList/TodoItemListViewController.swift
+++ b/TodoList/TodoItemListViewController.swift
@@ -81,7 +81,7 @@ class TodoItemListViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-        _viewModel.deleteItem.execute(parameter: indexPath.row as AnyObject)
+        _viewModel.deleteItem.execute(parameter: indexPath.row)
     }
 
 }

--- a/TodoList/TodoItemListViewModel.swift
+++ b/TodoList/TodoItemListViewModel.swift
@@ -22,7 +22,7 @@ class TodoItemListViewModel {
     
     var deleteItem: RelayCommand { return _deleteItem! }
     
-    private func executeDeleteItem(parameter: AnyObject?) {
+    private func executeDeleteItem(parameter: Any?) {
         let index = parameter as? Int
         if index == nil {
             return


### PR DESCRIPTION
`AnyObject`는 참조 타입에만 사용합니다. 참조 타입을 포함한 모든 값 타입에는 `Any`를 사용해야 합니다.