### PR TITLE
Unit 타입을 Void 타입으로 치환합니다.

### DIFF
--- a/TodoList/NewTodoItemFormViewController.swift
+++ b/TodoList/NewTodoItemFormViewController.swift
@@ -33,7 +33,7 @@ class NewTodoItemFormViewController: UIViewController {
                     break;
                 }
             }),
-            viewModel.submit.canExecuteChanged.subscribe(onNext: { unit in
+            viewModel.submit.canExecuteChanged.subscribe(onNext: {
                 let canExecuteCommand: Bool = viewModel.submit.canExecute()
                 self.submitButton.isEnabled = canExecuteCommand
             })

--- a/TodoList/RelayCommand.swift
+++ b/TodoList/RelayCommand.swift
@@ -13,7 +13,7 @@ class RelayCommand {
     
     private let _execute: (AnyObject?) -> Void
     private let _canExecute: (AnyObject?) -> Bool
-    private let _canExecuteChanged = PublishSubject<Unit>()
+    private let _canExecuteChanged = PublishSubject<Void>()
     
     init(execute: @escaping (AnyObject?) -> Void) {
         _execute = execute
@@ -25,7 +25,7 @@ class RelayCommand {
         _canExecute = canExecute
     }
     
-    var canExecuteChanged: Observable<Unit> { return _canExecuteChanged }
+    var canExecuteChanged: Observable<Void> { return _canExecuteChanged }
     
     func execute(parameter: AnyObject? = nil) {
         if canExecute(parameter: parameter) {
@@ -38,6 +38,6 @@ class RelayCommand {
     }
     
     func raiseCanExecuteChanged() {
-        _canExecuteChanged.onNext(Unit())
+        _canExecuteChanged.onNext(Void())
     }
 }

--- a/TodoListTests/NewTodoItemFormViewModel_specs.swift
+++ b/TodoListTests/NewTodoItemFormViewModel_specs.swift
@@ -69,7 +69,7 @@ class NewTodoItemFormViewModel_specs: XCTestCase {
         // Arrange
         let sut = NewTodoItemFormViewModel(itemList: TodoItemListViewModel(messageBox: StubMessageBox()))
         var monitor: Int = 0
-        _ = sut.submit.canExecuteChanged.subscribe(onNext: { Unit in monitor = monitor + 1 })
+        _ = sut.submit.canExecuteChanged.subscribe(onNext: { monitor = monitor + 1 })
         
         // Act
         sut.description = UUID().uuidString

--- a/TodoListTests/RelayCommand_specs.swift
+++ b/TodoListTests/RelayCommand_specs.swift
@@ -51,7 +51,7 @@ class RelayCommand_specs: XCTestCase {
     func test_raiseCanExecuteChanged_raises_canExecuteChanged_event() {
         // Arrange
         let sut = RelayCommand(execute: { Void in })
-        var events = [Unit]()
+        var events = [Void]()
         _ = sut.canExecuteChanged.subscribe(onNext: { event in events.append(event) })
         
         // Act


### PR DESCRIPTION
자세히 알지는 못하지만 C#에서는 Unit이라는 타입이 Void처럼 사용될 수 있나봅니다. Cocoa에서의 Unit은 문자 그대로 cm, mm등을 나타내는 단위입니다. `Unit`을 사용한 코드를 `Void`로 치환합니다.